### PR TITLE
Remove boost_system from linker flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ LIBS = libfritz++/libfritz++.a libnet++/libnet++.a liblog++/liblog++.a libconv++
 STATIC_LIB_DIRS = $(dir $(LIBS))
 STATIC_LIBS     = $(LIBS:%=$(CURDIR)/%)
 CXXFLAGS       += -I$(CURDIR) -std=c++11
-LDFLAGS        += -lboost_system -lboost_thread -lboost_regex -lpthread -lgcrypt
+LDFLAGS        += -lboost_thread -lboost_regex -lpthread -lgcrypt
 export STATIC_LIBS CXXFLAGS LDFLAGS
 
 ### Tests


### PR DESCRIPTION
Since Boost 1.69, boost_system has been header-only and no longer needs to be linked explicitly. The stub library was removed in Boost 1.89+, causing linker errors on systems with newer Boost versions.

Fixes #7